### PR TITLE
Minor changes to accessing_a_repo (Pablo)

### DIFF
--- a/tutorials/accessing_a_repo/accessing_a_repo.Rmd
+++ b/tutorials/accessing_a_repo/accessing_a_repo.Rmd
@@ -39,20 +39,22 @@ Make sure you have the most current version of [R and RStudio](https://github.co
 ### Create a GitHub account
 To get started, [signup](http://github.com) for a GitHub account, and provide your username to bbest@nceas.ucsb.edu or lowndes@nceas.ucsb.edu so you can access your ohi-[assessment] repository.
 
-### Install *git*
+### Install *git* Application
 *git* is required to work behind the scenes on your computer. [Download](http://git-scm.com/downloads) and install *git*. (Here are a few [tips](https://github.com/OHI-Science/ohiprep/wiki/Setup#git)).  
   
 You will then need to set up your Git Identity, which identifies you with any changes made. You will use the command line: 
 
-* **Mac**: launch the Terminal application
+* **Mac**: launch the Terminal application (Applications > Utilities > Terminal)
 * **Windows**: go to command line in Windows (Start > Run > cmd)  
   
 Substitute your GitHub user information with the user John Doe:
 
 ```{bash}
 git config --global user.name jdoe
+```
+
+```{bash}
 git config --global user.email johndoe@example.com
-git config --list
 ```
 
 You can check settings with the following:


### PR DESCRIPTION
- Added quick note about how to open terminal on a mac (Applications > Utilities > Terminal), similarly to what you had for a PC.
- Separate the lines of code for 'Substitute your GitHub user information with the user John Doe' so people don't try to run the whole thing at the same time, but rather run each line individually, and then check that it worked with the 'git config --list'.
